### PR TITLE
add set of meta-learners

### DIFF
--- a/meta_learners.R
+++ b/meta_learners.R
@@ -16,6 +16,10 @@ rec_pca <-
   rec_normalize %>%
   step_pca(all_predictors(), threshold = 1)
 
+rec_renormalize <-
+  rec_pca %>%
+  step_normalize(all_numeric_predictors())
+
 # model specifications ---------------------------------------------------------
 # this will just be set as the current default meta-learner with no recipe
 spec_glmnet <- linear_reg()
@@ -65,6 +69,17 @@ meta_learners <-
   bind_rows(
     workflow_set(
       preproc = list(pca = rec_pca),
+      models = list(
+        bag_tree = spec_bt,
+        bag_mars = spec_bm,
+        svm_rbf = spec_svm,
+        mlp = spec_nn
+      )
+    )
+  ) %>%
+  bind_rows(
+    workflow_set(
+      preproc = list(renormalize = rec_renormalize),
       models = list(bag_tree = spec_bt, bag_mars = spec_bm)
     )
   )

--- a/meta_learners.R
+++ b/meta_learners.R
@@ -1,0 +1,70 @@
+# setup ------------------------------------------------------------------------
+library(tidymodels)
+
+ex_dat <- tibble(outcome = rnorm(5), predictor_1 = rnorm(5), predictor_2 = rnorm(5))
+
+# recipes ----------------------------------------------------------------------
+rec_basic <- 
+  recipe(outcome ~ ., data = ex_dat) %>%
+  step_zv(all_predictors())
+
+rec_normalize <-
+  rec_basic %>% 
+  step_normalize(all_numeric_predictors())
+
+rec_pca <-
+  rec_normalize %>%
+  step_pca(all_predictors(), threshold = 1)
+
+# model specifications ---------------------------------------------------------
+# this will just be set as the current default meta-learner with no recipe
+spec_glmnet <- linear_reg()
+
+spec_bt <-
+  bag_tree(cost_complexity = tune(), tree_depth = tune(), min_n = tune()) %>%
+  set_engine("rpart") %>%
+  set_mode("regression")
+
+spec_bm <-
+  bag_mars(num_terms = tune(), prod_degree = tune()) %>%
+  set_engine("earth") %>% 
+  set_mode("regression")
+
+spec_svm <- 
+  svm_rbf(cost = tune(), rbf_sigma = tune(), margin = tune()) %>%
+  set_mode("regression")
+
+spec_nn <-
+  mlp(hidden_units = tune(), penalty = tune(), epochs = tune()) %>%
+  set_engine("nnet") %>%
+  set_mode("regression")
+
+spec_xgb <-
+  boost_tree(trees = tune(), min_n = tune(), tree_depth = tune(),
+             learn_rate = tune(), stop_iter = 10) %>%
+  set_engine("xgboost") %>%
+  set_mode("regression")
+
+
+meta_learners <-
+  workflow_set(
+    preproc = list(basic = rec_basic),
+    models = list(linear_reg = spec_glmnet, boost_tree = spec_xgb)
+  ) %>%
+  bind_rows(
+    workflow_set(
+      preproc = list(normalize = rec_normalize),
+      models = list(
+        bag_tree = spec_bt,
+        bag_mars = spec_bm,
+        svm_rbf = spec_svm,
+        mlp = spec_nn
+      )
+    )
+  )  %>%
+  bind_rows(
+    workflow_set(
+      preproc = list(pca = rec_pca),
+      models = list(bag_tree = spec_bt, bag_mars = spec_bm)
+    )
+  )


### PR DESCRIPTION
A proposed standard set of meta learners to benchmark against each other. Once we feel good about this set, I can go ahead and write the scripts for each benchmark.

``` r
meta_learners
#> # A workflow set/tibble: 8 × 4
#>   wflow_id           info             option    result    
#>   <chr>              <list>           <list>    <list>    
#> 1 basic_linear_reg   <tibble [1 × 4]> <opts[0]> <list [0]>
#> 2 basic_boost_tree   <tibble [1 × 4]> <opts[0]> <list [0]>
#> 3 normalize_bag_tree <tibble [1 × 4]> <opts[0]> <list [0]>
#> 4 normalize_bag_mars <tibble [1 × 4]> <opts[0]> <list [0]>
#> 5 normalize_svm_rbf  <tibble [1 × 4]> <opts[0]> <list [0]>
#> 6 normalize_mlp      <tibble [1 × 4]> <opts[0]> <list [0]>
#> 7 pca_bag_tree       <tibble [1 × 4]> <opts[0]> <list [0]>
#> 8 pca_bag_mars       <tibble [1 × 4]> <opts[0]> <list [0]>
```